### PR TITLE
Fixed bugs , added 2 opcodes, fixed return handling and packed-switch

### DIFF
--- a/smali/object_mapping.py
+++ b/smali/object_mapping.py
@@ -70,7 +70,9 @@ class ObjectMapping(object):
         class_name = self.__demangle_class_name( vm, klass )
         if class_name in self.mapping:
             if method_name in self.mapping[class_name]:
-                self.mapping[class_name][method_name]( vm, this, args )
+                invokeResult = self.mapping[class_name][method_name]( vm, this, args )
+                if not invokeResult is None:
+                    vm.return_v = invokeResult
 
             else:
                 vm.emu.fatal("Unsupported method '%s' for class '%s'." % ( method_name, class_name ))

--- a/smali/opcodes.py
+++ b/smali/opcodes.py
@@ -387,11 +387,10 @@ class op_Return(OpCode):
 
     @staticmethod
     def eval(vm, ctype, vx):
-        if ctype is None or ctype == '-void':
+        if (ctype is None and vx is None) or ctype == '-void':
             vm.return_v = None
             vm.stop = True
-
-        elif ctype in ( '-wide', '-object' ):
+        elif ctype in ( '-wide', '-object' ) or (ctype is None and vx is not None):
             vm.return_v = vm[vx]
             vm.stop = True
 

--- a/smali/opcodes.py
+++ b/smali/opcodes.py
@@ -57,7 +57,7 @@ class op_Const(OpCode):
 
 class op_ConstString(OpCode):
     def __init__(self):
-        OpCode.__init__(self, '^const-string(?:/jumbo)? (.+),\s*"([^"]*)"')
+        OpCode.__init__(self, '^const-string(?:/jumbo)? (.+),\s*"(.*)"')
 
     @staticmethod
     def eval(vm, vx, s):
@@ -338,7 +338,7 @@ class op_APut(OpCode):
 
 class op_Invoke(OpCode):
     def __init__(self):
-        OpCode.__init__(self, '^invoke-([a-z]+) \{(.+)\},\s*(.+)')
+        OpCode.__init__(self, '^invoke-([a-z]+) \{(.*)\},\s*(.+)')
 
     @staticmethod
     def eval(vm, _, args, call):

--- a/smali/opcodes.py
+++ b/smali/opcodes.py
@@ -361,18 +361,38 @@ class op_IntToType(OpCode):
         else:
             vm.emu.fatal( "Unsupported type '%s'." % ctype )
 
+class op_SPut(OpCode):
+    def __init__(self):
+        #sput-object v9, Lcom/whatsapp/messaging/a;->z:[Ljava/lang/String;
+        #aput-object v6, v8, v7
+        OpCode.__init__(self, '^sput-object+\s(.+),\s*(.+)')
+
+    @staticmethod
+    def eval(vm, vx, staticVariableName):
+        vm.variables[staticVariableName] = vm.variables[vx]
+
+class op_SGet(OpCode):
+    def __init__(self):
+        #sput-object v9, Lcom/whatsapp/messaging/a;->z:[Ljava/lang/String;
+        #aput-object v6, v8, v7
+        OpCode.__init__(self, '^sget-object+\s(.+),\s*(.+)')
+
+    @staticmethod
+    def eval(vm, vx, staticVariableName):
+        vm.variables[vx] = vm.variables[staticVariableName]
+
 class op_Return(OpCode):
     def __init__(self):
-        OpCode.__init__(self, '^return(-[a-z]+)?\s*(.+)')
+        OpCode.__init__(self, '^return(-[a-z]*)*\s*(.+)*')
 
     @staticmethod
     def eval(vm, ctype, vx):
-        if ctype in ( None, '', '-wide', '-object' ):
-            vm.return_v = vm[vx]
+        if ctype is None or ctype == '-void':
+            vm.return_v = None
             vm.stop = True
 
-        elif ctype == '-void':
-            vm.return_v = None
+        elif ctype in ( '-wide', '-object' ):
+            vm.return_v = vm[vx]
             vm.stop = True
 
         else:

--- a/smali/opcodes.py
+++ b/smali/opcodes.py
@@ -417,7 +417,7 @@ class op_PackedSwitch(OpCode):
         cases = switch.get('cases', [])
         case_idx = val - switch.get('first_value')
 
-        if case_idx >= len(cases):
+        if case_idx >= len(cases) or case_idx < 0:
             return
 
         case_label = cases[case_idx]

--- a/tests/data/packed-switch-fallthrough-indextooBig.smali
+++ b/tests/data/packed-switch-fallthrough-indextooBig.smali
@@ -1,0 +1,30 @@
+# {'a': 15, 'b': 0, 'ret': None}
+
+const/16 a, 15
+const/16 b, 0
+
+packed-switch a, :pswitch_data_0
+return-void
+
+const/16 b, 0xB
+
+:goto_0
+return b 
+
+:pswitch_2
+const/16 b, 0x8
+goto :goto_0
+
+:pswitch_1
+const/16 b, 0x9
+
+:pswitch_4
+const/16 b, 0xA
+goto :goto_0
+
+:pswitch_data_0
+.packed-switch 0x8
+    :pswitch_2
+    :pswitch_1
+    :pswitch_4
+.end packed-switch

--- a/tests/data/packed-switch-fallthrough-indextooSmall.smali
+++ b/tests/data/packed-switch-fallthrough-indextooSmall.smali
@@ -1,0 +1,30 @@
+# {'a': 7, 'b': 0, 'ret': None}
+
+const/16 a, 7
+const/16 b, 0
+
+packed-switch a, :pswitch_data_0
+return-void
+
+const/16 b, 0xB
+
+:goto_0
+return b 
+
+:pswitch_2
+const/16 b, 0x8
+goto :goto_0
+
+:pswitch_1
+const/16 b, 0x9
+
+:pswitch_4
+const/16 b, 0xA
+goto :goto_0
+
+:pswitch_data_0
+.packed-switch 0x8
+    :pswitch_2
+    :pswitch_1
+    :pswitch_4
+.end packed-switch

--- a/tests/data/sget.smali
+++ b/tests/data/sget.smali
@@ -1,0 +1,19 @@
+# {'va': u'Hello', 'ret': None, 'statMember': u'Hello'}
+
+.field private static final statMember:Ljava/lang/String;
+
+const-string va, "Hello"
+
+sput-object va, statMember
+
+return
+
+# {'a': [u'a', u'b', u'c'], 'i': 1, 's': u'abc', 'ret': [u'a', u'b', u'c'], 'v': u'b'}
+const-string s, "abc"
+const/16 a, 0
+const/16 i, 1
+const/16 v, 0
+
+invoke-virtual {s}, Ljava/lang/String;->toCharArray()[C
+move-result a
+aget v, a, i

--- a/tests/data/sput.smali
+++ b/tests/data/sput.smali
@@ -1,0 +1,11 @@
+# {'va': u'Hello', 'vb': u'Hello', 'ret': u'Hello', 'statMember': u'Hello'}
+
+.field private static final statMember:Ljava/lang/String;
+
+const-string va, "Hello"
+
+sput-object va, statMember
+
+sget-object vb, statMember
+
+return-object vb


### PR DESCRIPTION
Hi,

Added support for SPUT and SGET.
Fixed handling for return-void.
Added handling for every method invocation should set the return_v member. ( usually after invoke method you can see the "move-result-object " statement.
added tests.